### PR TITLE
Add 'orientation' property for images on Android

### DIFF
--- a/android/src/main/java/fr/bamlab/rncameraroll/CameraImage.java
+++ b/android/src/main/java/fr/bamlab/rncameraroll/CameraImage.java
@@ -1,6 +1,9 @@
 package fr.bamlab.rncameraroll;
 
 import android.graphics.BitmapFactory;
+import android.media.ExifInterface;
+
+import java.io.IOException;
 
 /**
  * Created by florian on 02/12/15.
@@ -9,11 +12,13 @@ class CameraImage {
     private String localPath;
     private int width;
     private int height;
+    private int orientation;
 
     CameraImage(String localPath) {
         this.localPath = localPath;
 
         computeDimensions();
+        computeOrientation();
     };
 
     private void computeDimensions() {
@@ -23,6 +28,33 @@ class CameraImage {
         BitmapFactory.decodeFile(this.localPath, options);
         width = options.outWidth;
         height = options.outHeight;
+    }
+
+    private void computeOrientation() {
+        ExifInterface exif;
+        orientation = 0;
+        try {
+            exif = new ExifInterface(localPath);
+            int exifOrientation = exif.getAttributeInt(
+                    ExifInterface.TAG_ORIENTATION,
+                    ExifInterface.ORIENTATION_NORMAL);
+
+            switch (exifOrientation) {
+                case ExifInterface.ORIENTATION_ROTATE_90:
+                    orientation = 90;
+                    break;
+
+                case ExifInterface.ORIENTATION_ROTATE_180:
+                    orientation = 180;
+                    break;
+
+                case ExifInterface.ORIENTATION_ROTATE_270:
+                    orientation = 270;
+                    break;
+            }
+        } catch (IOException e) {
+            // Can't retrieve the orientation, let it to 0.
+        }
     }
 
     public String getLocalPath() {
@@ -35,5 +67,9 @@ class CameraImage {
 
     public int getHeight() {
         return height;
+    }
+
+    public int getOrientation() {
+        return orientation;
     }
 }

--- a/android/src/main/java/fr/bamlab/rncameraroll/CameraRollModule.java
+++ b/android/src/main/java/fr/bamlab/rncameraroll/CameraRollModule.java
@@ -43,6 +43,7 @@ class CameraRollModule extends ReactContextBaseJavaModule {
             imageDataMap.putString("uri", imageData.getLocalPath());
             imageDataMap.putInt("width", imageData.getWidth());
             imageDataMap.putInt("height", imageData.getHeight());
+            imageDataMap.putInt("orientation", imageData.getOrientation());
 
             result.pushMap(imageDataMap);
         }

--- a/index.android.js
+++ b/index.android.js
@@ -12,6 +12,7 @@ function formatToIosCameraRollFormat(imageDataList) {
             uri: ANDROID_FILE_PREFIX + imageData.uri,
             width: imageData.width,
             height: imageData.height,
+            orientation: imageData.orientation,
           },
         },
       };


### PR DESCRIPTION
"Non standard" attribute as it does not exist on iOS, but enables to properly rotate the images when displaying them on Android.
