### PR TITLE
Add timestamp for compatibility with CameraRoll on iOS

### DIFF
--- a/android/src/main/java/fr/bamlab/rncameraroll/CameraImage.java
+++ b/android/src/main/java/fr/bamlab/rncameraroll/CameraImage.java
@@ -2,6 +2,7 @@ package fr.bamlab.rncameraroll;
 
 import android.graphics.BitmapFactory;
 import android.media.ExifInterface;
+import java.text.SimpleDateFormat;
 
 import java.io.IOException;
 
@@ -13,12 +14,14 @@ class CameraImage {
     private int width;
     private int height;
     private int orientation;
+    private long timestamp;
 
     CameraImage(String localPath) {
         this.localPath = localPath;
 
         computeDimensions();
         computeOrientation();
+        computeTimestamp();
     };
 
     private void computeDimensions() {
@@ -57,6 +60,19 @@ class CameraImage {
         }
     }
 
+    private void computeTimestamp() {
+        try {
+            SimpleDateFormat fmt = new SimpleDateFormat("yyyy:MM:dd HH:mm:ss");
+
+            ExifInterface exif = new ExifInterface(localPath);
+            String dateString = exif.getAttribute(ExifInterface.TAG_DATETIME);
+
+            timestamp = fmt.parse(dateString).getTime() / 1000;
+        } catch (Exception e) {
+            // Can't retrieve the timestamp, let it be 0.
+        }
+    }
+
     public String getLocalPath() {
         return localPath;
     }
@@ -71,5 +87,9 @@ class CameraImage {
 
     public int getOrientation() {
         return orientation;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
     }
 }

--- a/android/src/main/java/fr/bamlab/rncameraroll/CameraRollModule.java
+++ b/android/src/main/java/fr/bamlab/rncameraroll/CameraRollModule.java
@@ -44,6 +44,7 @@ class CameraRollModule extends ReactContextBaseJavaModule {
             imageDataMap.putInt("width", imageData.getWidth());
             imageDataMap.putInt("height", imageData.getHeight());
             imageDataMap.putInt("orientation", imageData.getOrientation());
+            imageDataMap.putString("timestamp", Long.toString(imageData.getTimestamp()));
 
             result.pushMap(imageDataMap);
         }

--- a/index.android.js
+++ b/index.android.js
@@ -14,6 +14,7 @@ function formatToIosCameraRollFormat(imageDataList) {
             height: imageData.height,
             orientation: imageData.orientation,
           },
+          timestamp: parseInt(imageData.timestamp)
         },
       };
     }),


### PR DESCRIPTION
The timestamp is passed from the Java side as a String since WritableMap doesn't support `long`, and then parsed to an integer on the JavaScript side since that's how the iOS CameraRoll returns it.
